### PR TITLE
Basic Lighting and Infinite Grid

### DIFF
--- a/libs/scene/src/light.zig
+++ b/libs/scene/src/light.zig
@@ -1,0 +1,13 @@
+const zmath = @import("zmath");
+
+pub const Light = struct {
+    color: zmath.Vec,
+    ambientIntensity: f32,
+};
+
+pub fn newLight(red: f32, green: f32, blue: f32, ambientIntensity: f32) Light {
+    return Light {
+        .color = .{red, green, blue, 1},
+        .ambientIntensity = ambientIntensity,
+    };
+}

--- a/libs/scene/src/light.zig
+++ b/libs/scene/src/light.zig
@@ -1,8 +1,8 @@
 const zmath = @import("zmath");
 
-pub const Light = struct {
-    color: @Vector(4, f32),
-    direction: @Vector(4, f32),
+pub const Light = packed struct {
+    color: @Vector(3, f32),
+    direction: @Vector(3, f32),
     ambientIntensity: f32,
     diffuseIntensity: f32,
 };

--- a/libs/scene/src/light.zig
+++ b/libs/scene/src/light.zig
@@ -1,13 +1,8 @@
 const zmath = @import("zmath");
 
 pub const Light = struct {
-    color: zmath.Vec,
+    color: @Vector(4, f32),
+    direction: @Vector(4, f32),
     ambientIntensity: f32,
+    diffuseIntensity: f32,
 };
-
-pub fn newLight(red: f32, green: f32, blue: f32, ambientIntensity: f32) Light {
-    return Light {
-        .color = .{red, green, blue, 1},
-        .ambientIntensity = ambientIntensity,
-    };
-}

--- a/libs/scene/src/mesh.zig
+++ b/libs/scene/src/mesh.zig
@@ -3,6 +3,7 @@ const zmath = @import("zmath");
 pub const Vertex = struct {
     position: @Vector(3, f32),
     color: @Vector(3, f32),
+    normal: @Vector(3, f32),
     uv: @Vector(2, f32),
 };
 

--- a/libs/scene/src/root.zig
+++ b/libs/scene/src/root.zig
@@ -2,4 +2,5 @@ pub usingnamespace @import("mesh.zig");
 pub usingnamespace @import("transform.zig");
 pub usingnamespace @import("camera.zig");
 pub usingnamespace @import("input.zig");
+pub usingnamespace @import("light.zig");
 pub usingnamespace @import("scene.zig");

--- a/libs/scene/src/scene.zig
+++ b/libs/scene/src/scene.zig
@@ -40,10 +40,10 @@ fn createCamera(it: *ecs.iter_t) callconv(.C) void {
     _ = ecs.set(it.world, camera_entity, Camera, camera);
 
     _ = ecs.set(it.world, camera_entity, Light, .{
-        .color = .{ 1, 1, 1, 1 },
-        .direction = .{ 0.0, 0.4, 1.0, 1.0 },
-        .ambientIntensity = 0.4,
-        .diffuseIntensity = 0.8,
+        .color = .{ 1, 1, 1 },
+        .direction = .{ 0.0, 0.5, 1.0 },
+        .ambientIntensity = 1,
+        .diffuseIntensity = 1,
     });
 }
 
@@ -308,7 +308,7 @@ fn simpleSceneSetUp(it: *ecs.iter_t) callconv(.C) void {
     _ = ecs.set(it.world, entity2, transform.Speed, transform.Speed{ .value = 50 });
 
     var t2 = zmath.identity();
-    t2 = zmath.mul(zmath.translationV(.{ 0, 0, -8, 1 }), t2);
+    t2 = zmath.mul(zmath.translationV(.{ 0, 0.5, -7, 1 }), t2);
     _ = ecs.set(it.world, entity2, transform.Transform, transform.Transform{
         .value = t2,
     });

--- a/libs/scene/src/scene.zig
+++ b/libs/scene/src/scene.zig
@@ -23,7 +23,7 @@ fn createCamera(it: *ecs.iter_t) callconv(.C) void {
 
     const camera_entity = ecs.new_id(it.world);
     _ = ecs.add(it.world, camera_entity, CameraController);
-    _ = ecs.set(it.world, camera_entity, transform.Position, .{ .x = 0, .y = 0, .z = 5 });
+    _ = ecs.set(it.world, camera_entity, transform.Position, .{ .x = 0, .y = 0.1, .z = 5 });
     _ = ecs.set(it.world, camera_entity, transform.Orientation, .{ .quat = zmath.qidentity() });
     _ = ecs.set(it.world, camera_entity, transform.Velocity, std.mem.zeroInit(transform.Velocity, .{}));
     _ = ecs.set(it.world, camera_entity, transform.AngularVelocity, std.mem.zeroInit(transform.AngularVelocity, .{}));
@@ -98,10 +98,10 @@ fn updateCamera(it: *ecs.iter_t) callconv(.C) void {
         }
 
         if (input.keys[ux.KEY_UP].state) {
-            angular_vel.x -= angular_acceleration;
+            angular_vel.x += angular_acceleration;
         }
         if (input.keys[ux.KEY_DOWN].state) {
-            angular_vel.x += angular_acceleration;
+            angular_vel.x -= angular_acceleration;
         }
 
         _ = ecs.set(it.world, e, transform.Velocity, vel);

--- a/libs/scene/src/scene.zig
+++ b/libs/scene/src/scene.zig
@@ -7,6 +7,7 @@ const transform = @import("transform.zig");
 const ux = @import("input.zig");
 const Camera = @import("camera.zig").Camera;
 const Perspective = @import("camera.zig").Perspective;
+const Light = @import("light.zig").Light;
 
 const CameraDeceleration: f32 = 70;
 const CameraAcceleration: f32 = 50 + CameraDeceleration;
@@ -42,6 +43,12 @@ fn createCamera(it: *ecs.iter_t) callconv(.C) void {
     };
     camera.projection[1][1] *= -1;
     _ = ecs.set(it.world, camera_entity, Camera, camera);
+
+    _ = ecs.set(it.world, camera_entity, Light, .{
+        .color = .{1, 1, 1, 1},
+        .ambientIntensity = 0.2,
+    });
+
 }
 
 fn updateCamera(it: *ecs.iter_t) callconv(.C) void {
@@ -328,6 +335,7 @@ fn spinTransform(it: *ecs.iter_t) callconv(.C) void {
 
 pub fn init(world: *ecs.world_t) void {
     ecs.COMPONENT(world, Camera);
+    ecs.COMPONENT(world, Light);
     ecs.COMPONENT(world, mesh.Mesh);
     ecs.COMPONENT(world, transform.Position);
     ecs.COMPONENT(world, transform.Orientation);

--- a/libs/scene/src/scene.zig
+++ b/libs/scene/src/scene.zig
@@ -297,7 +297,7 @@ fn simpleSceneSetUp(it: *ecs.iter_t) callconv(.C) void {
     _ = ecs.set(it.world, entity, transform.Speed, transform.Speed{ .value = 20 });
 
     var t1 = zmath.identity();
-    t1 = zmath.mul(zmath.translationV(.{ 0, 0, -2.5, 1 }), t1);
+    t1 = zmath.mul(zmath.translationV(.{ 0, 0, -4.5, 1 }), t1);
     _ = ecs.set(it.world, entity, transform.Transform, transform.Transform{
         .value = t1,
     });
@@ -308,7 +308,7 @@ fn simpleSceneSetUp(it: *ecs.iter_t) callconv(.C) void {
     _ = ecs.set(it.world, entity2, transform.Speed, transform.Speed{ .value = 50 });
 
     var t2 = zmath.identity();
-    t2 = zmath.mul(zmath.translationV(.{ 0, 0, -3, 1 }), t2);
+    t2 = zmath.mul(zmath.translationV(.{ 0, 0, -8, 1 }), t2);
     _ = ecs.set(it.world, entity2, transform.Transform, transform.Transform{
         .value = t2,
     });

--- a/shaders/gradient.comp.glsl
+++ b/shaders/gradient.comp.glsl
@@ -1,0 +1,21 @@
+#version 460
+
+layout (local_size_x = 16, local_size_y = 16) in;
+layout (rgba16f, set = 0, binding = 0) uniform image2D image;
+
+void main()  {
+    ivec2 texelCoord = ivec2(gl_GlobalInvocationID.xy);
+    ivec2 size = imageSize(image);
+
+    if (texelCoord.x >= size.x || texelCoord.y >= size.y) {
+        return;
+    }
+
+    vec4 color = vec4(0.0, 0.0, 0.0, 1.0);
+    if (gl_LocalInvocationID.x != 0 && gl_LocalInvocationID.y != 0) {
+        color.x = float(texelCoord.x) / float(size.x);
+        color.y = float(texelCoord.y) / float(size.y);
+    }
+
+    imageStore(image, texelCoord, color);
+}

--- a/shaders/grid.frag.glsl
+++ b/shaders/grid.frag.glsl
@@ -1,0 +1,8 @@
+#version 460
+
+layout(location = 0) out vec4 outColor;
+
+void main()
+{
+    outColor = vec4(1.0, 0.0, 0.0, 1.0);
+}

--- a/shaders/grid.frag.glsl
+++ b/shaders/grid.frag.glsl
@@ -1,8 +1,56 @@
 #version 460
 
+layout(location = 0) in float near;
+layout(location = 1) in float far;
+layout(location = 2) in vec3 nearPoint;
+layout(location = 3) in vec3 farPoint;
+layout(location = 4) in mat4 view;
+layout(location = 8) in mat4 projection;
+
 layout(location = 0) out vec4 outColor;
+
+vec4 grid(vec3 fragPos3D, float scale) {
+    vec2 coord = fragPos3D.xz * scale; // use the scale variable to set the distance between the lines
+    vec2 derivative = fwidth(coord);
+    vec2 grid = abs(fract(coord - 0.5) - 0.5) / derivative;
+    float line = min(grid.x, grid.y);
+    float minimumz = min(derivative.y, 1);
+    float minimumx = min(derivative.x, 1);
+
+    vec4 color = vec4(0.2, 0.2, 0.2, 1.0 - min(line, 1.0));
+    if(fragPos3D.x > -0.1 * minimumx && fragPos3D.x < 0.1 * minimumx) {
+        color.z = 1.0;
+    }
+
+    if(fragPos3D.z > -0.1 * minimumz && fragPos3D.z < 0.1 * minimumz) {
+        color.x = 1.0;
+    }
+
+    return color;
+}
+
+float depth(vec3 pos) {
+    vec4 clipPos = projection * view * vec4(pos, 1.0);
+    return clipPos.z / clipPos.w;
+}
+
+float linearDepth(vec3 pos) {
+    vec4 clipSpacePos = projection * view * vec4(pos.xyz, 1.0);
+    float clipSpaceDepth = (clipSpacePos.z / clipSpacePos.w) * 2.0 - 1.0; // put back between -1 and 1
+    float linearDepth = (2.0 * near * far) / (far + near - clipSpaceDepth * (far - near));
+    return linearDepth / far;
+}
 
 void main()
 {
-    outColor = vec4(1.0, 0.0, 0.0, 1.0);
+    float t = -nearPoint.y / (farPoint.y - nearPoint.y);
+    vec3 fragPos3D = nearPoint + t * (farPoint - nearPoint);
+
+    gl_FragDepth = depth(fragPos3D);
+
+    float linearDepth = linearDepth(fragPos3D);
+    float fading = max(0, (0.5 - linearDepth));
+    
+    outColor = grid(fragPos3D, 5) * float(t > 0);
+    outColor.a *= fading;
 }

--- a/shaders/grid.vert.glsl
+++ b/shaders/grid.vert.glsl
@@ -30,6 +30,6 @@ void main() {
     
     // gl_PointSize = 1.0;
 
-    gl_Position = vec4(gridPlane[gl_VertexIndex].xyz, 1.0);
+    gl_Position = camera.projection * camera.view * vec4(gridPlane[gl_VertexIndex].xyz, 1.0);
     
 }

--- a/shaders/grid.vert.glsl
+++ b/shaders/grid.vert.glsl
@@ -1,0 +1,41 @@
+#version 460
+
+float gridSize = 100.0;
+float gridCellSize = 0.025;
+vec4 gridColorThinLine = vec4(0.5, 0.5, 0.5, 1.0);
+vec4 gridColorThickLine = vec4(0.0, 0.0, 0.0, 1.0);
+const float gridMinPixelsBetweenCells = 2.0;
+
+const vec3 grid_pos[4] = vec3[4](
+	vec3(-1.0, 0.0, -1.0),
+	vec3( 1.0, 0.0, -1.0),
+	vec3( 1.0, 0.0,  1.0),
+	vec3(-1.0, 0.0,  1.0)
+);
+
+const int grid_indices[6] = int[6](
+	0, 1, 2, 2, 3, 0
+);
+
+layout(set = 0, binding = 0) uniform Camera {
+    mat4 view;
+    mat4 projection;
+} camera;
+
+// layout(location = 0) out vec2 gridUV;
+// layout(location = 1) out vec3 cameraPos;
+
+void main() {
+    
+    // vec3 worldPos = grid_pos[gl_VertexIndex];
+    // vec4 clipPos = camera.projection * camera.view * vec4(worldPos, 1.0);
+    // gl_Position = clipPos;
+    
+    // gridUV = worldPos.xz;
+    // cameraPos = camera.view[3].xyz;
+    
+    // gl_PointSize = 1.0;
+
+    gl_Position = vec4(grid_pos[grid_indices[gl_VertexIndex]], 1.0);
+    
+}

--- a/shaders/grid.vert.glsl
+++ b/shaders/grid.vert.glsl
@@ -1,11 +1,5 @@
 #version 460
 
-float gridSize = 100.0;
-float gridCellSize = 0.025;
-vec4 gridColorThinLine = vec4(0.5, 0.5, 0.5, 1.0);
-vec4 gridColorThickLine = vec4(0.0, 0.0, 0.0, 1.0);
-const float gridMinPixelsBetweenCells = 2.0;
-
 vec3 gridPlane[6] = vec3[](
     vec3(1, 1, 0), vec3(-1, -1, 0), vec3(-1, 1, 0),
     vec3(-1, -1, 0), vec3(1, 1, 0), vec3(1, -1, 0)
@@ -16,20 +10,30 @@ layout(set = 0, binding = 0) uniform Camera {
     mat4 projection;
 } camera;
 
-// layout(location = 0) out vec2 gridUV;
-// layout(location = 1) out vec3 cameraPos;
+layout(location = 0) out float near;
+layout(location = 1) out float far;
+layout(location = 2) out vec3 nearPoint;
+layout(location = 3) out vec3 farPoint;
+layout(location = 4) out mat4 view;
+layout(location = 8) out mat4 projection;
+
+vec3 unprojectPoint(float x, float y, float z, mat4 view, mat4 projection) {
+    vec4 clipSpace = vec4(x, y, z, 1.0);
+    vec4 eyeSpace = inverse(projection) * clipSpace;
+    vec4 worldSpace = inverse(view) * eyeSpace;
+    return worldSpace.xyz / worldSpace.w;
+}
 
 void main() {
-    
-    // vec3 worldPos = grid_pos[gl_VertexIndex];
-    // vec4 clipPos = camera.projection * camera.view * vec4(worldPos, 1.0);
-    // gl_Position = clipPos;
-    
-    // gridUV = worldPos.xz;
-    // cameraPos = camera.view[3].xyz;
-    
-    // gl_PointSize = 1.0;
+    vec3 point = gridPlane[gl_VertexIndex];
 
-    gl_Position = camera.projection * camera.view * vec4(gridPlane[gl_VertexIndex].xyz, 1.0);
-    
+    near = 0.1;
+    far = 100.0;
+    nearPoint = unprojectPoint(point.x, point.y, 0.0, camera.view, camera.projection).xyz;
+    farPoint = unprojectPoint(point.x, point.y, 1.0, camera.view, camera.projection).xyz;
+    view = camera.view;
+    projection = camera.projection;
+
+    gl_Position = vec4(point, 1.0);
 }
+

--- a/shaders/grid.vert.glsl
+++ b/shaders/grid.vert.glsl
@@ -6,15 +6,9 @@ vec4 gridColorThinLine = vec4(0.5, 0.5, 0.5, 1.0);
 vec4 gridColorThickLine = vec4(0.0, 0.0, 0.0, 1.0);
 const float gridMinPixelsBetweenCells = 2.0;
 
-const vec3 grid_pos[4] = vec3[4](
-	vec3(-1.0, 0.0, -1.0),
-	vec3( 1.0, 0.0, -1.0),
-	vec3( 1.0, 0.0,  1.0),
-	vec3(-1.0, 0.0,  1.0)
-);
-
-const int grid_indices[6] = int[6](
-	0, 1, 2, 2, 3, 0
+vec3 gridPlane[6] = vec3[](
+    vec3(1, 1, 0), vec3(-1, -1, 0), vec3(-1, 1, 0),
+    vec3(-1, -1, 0), vec3(1, 1, 0), vec3(1, -1, 0)
 );
 
 layout(set = 0, binding = 0) uniform Camera {
@@ -36,6 +30,6 @@ void main() {
     
     // gl_PointSize = 1.0;
 
-    gl_Position = vec4(grid_pos[grid_indices[gl_VertexIndex]], 1.0);
+    gl_Position = vec4(gridPlane[gl_VertexIndex].xyz, 1.0);
     
 }

--- a/shaders/shader.frag.glsl
+++ b/shaders/shader.frag.glsl
@@ -5,8 +5,8 @@ layout(location = 1) in vec2 fragUV;
 layout(location = 2) in vec3 fragNormal;
 
 layout(set = 1, binding = 0) uniform Light {
-    vec4 color;
-    vec4 direction;
+    vec3 color;
+    vec3 direction;
     float ambientIntensity;
     float diffuseIntensity;
 } light;
@@ -16,12 +16,12 @@ layout(set = 2, binding = 0) uniform sampler2D textureSampler;
 layout(location = 0) out vec4 outColor;
 
 void main() {
-    vec4 ambientColor = light.color * light.ambientIntensity;
+    vec4 ambientColor = vec4(light.color, 1.0) * light.ambientIntensity;
 
     // A.B = |A| * |B| * cos(theta), since we normalize A and B, it is 1 * 1 * cos(theta) = cos(theta)
     vec3 lightDir = normalize(-light.direction.xyz);
     float diffuseFactor = max(dot(fragNormal, lightDir), 0.0f);
-    vec4 diffuseColor = light.color * light.diffuseIntensity * diffuseFactor;
+    vec4 diffuseColor = vec4(light.color, 1.0) * light.diffuseIntensity * diffuseFactor;
 
     outColor = texture(textureSampler, fragUV) * (ambientColor + diffuseColor);
 }

--- a/shaders/shader.frag.glsl
+++ b/shaders/shader.frag.glsl
@@ -1,19 +1,27 @@
-#version 450
+#version 460
 
 layout(location = 0) in vec3 fragCol;
 layout(location = 1) in vec2 fragUV;
-
-layout(set = 1, binding = 0) uniform sampler2D textureSampler;
+layout(location = 2) in vec3 fragNormal;
 
 layout(set = 0, binding = 1) uniform Light {
     vec4 color;
+    vec4 direction;
     float ambientIntensity;
+    float diffuseIntensity;
 } light;
+
+layout(set = 1, binding = 0) uniform sampler2D textureSampler;
 
 layout(location = 0) out vec4 outColor;
 
 void main() {
     vec4 ambientColor = light.color * light.ambientIntensity;
-    // outColor = vec4(fragCol, 1.0);
-    outColor = texture(textureSampler, fragUV) * ambientColor;
+
+    // A.B = |A| * |B| * cos(theta), since we normalize A and B, it is 1 * 1 * cos(theta) = cos(theta)
+    vec3 lightDir = normalize(-light.direction.xyz);
+    float diffuseFactor = max(dot(fragNormal, lightDir), 0.0f);
+    vec4 diffuseColor = light.color * light.diffuseIntensity * diffuseFactor;
+
+    outColor = texture(textureSampler, fragUV) * (ambientColor + diffuseColor);
 }

--- a/shaders/shader.frag.glsl
+++ b/shaders/shader.frag.glsl
@@ -4,14 +4,14 @@ layout(location = 0) in vec3 fragCol;
 layout(location = 1) in vec2 fragUV;
 layout(location = 2) in vec3 fragNormal;
 
-layout(set = 0, binding = 1) uniform Light {
+layout(set = 1, binding = 0) uniform Light {
     vec4 color;
     vec4 direction;
     float ambientIntensity;
     float diffuseIntensity;
 } light;
 
-layout(set = 1, binding = 0) uniform sampler2D textureSampler;
+layout(set = 2, binding = 0) uniform sampler2D textureSampler;
 
 layout(location = 0) out vec4 outColor;
 

--- a/shaders/shader.frag.glsl
+++ b/shaders/shader.frag.glsl
@@ -5,9 +5,15 @@ layout(location = 1) in vec2 fragUV;
 
 layout(set = 1, binding = 0) uniform sampler2D textureSampler;
 
+layout(set = 0, binding = 1) uniform Light {
+    vec4 color;
+    float ambientIntensity;
+} light;
+
 layout(location = 0) out vec4 outColor;
 
 void main() {
+    vec4 ambientColor = light.color * light.ambientIntensity;
     // outColor = vec4(fragCol, 1.0);
-    outColor = texture(textureSampler, fragUV);
+    outColor = texture(textureSampler, fragUV) * ambientColor;
 }

--- a/shaders/shader.vert.glsl
+++ b/shaders/shader.vert.glsl
@@ -1,8 +1,9 @@
-#version 450
+#version 460
 
 layout(location = 0) in vec3 pos;
 layout(location = 1) in vec3 col;
-layout(location = 2) in vec2 uv;
+layout(location = 2) in vec3 normal;
+layout(location = 3) in vec2 uv;
 
 layout(set = 0, binding = 0) uniform Camera {
     mat4 view;
@@ -19,10 +20,13 @@ layout(push_constant) uniform UBO {
 
 layout(location = 0) out vec3 fragCol;
 layout(location = 1) out vec2 fragUV;
+layout(location = 2) out vec3 fragNormal;
 
 void main() {
     gl_Position = camera.projection * camera.view * ubo.model * vec4(pos, 1.0);
     // gl_Position = vec4(pos, 1.0);
     fragCol = col;
     fragUV = uv;
+
+    fragNormal = mat3(transpose(inverse(ubo.model))) * normal;
 }

--- a/src/vulkan/compute.zig
+++ b/src/vulkan/compute.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+const c = @import("../clibs.zig");
+const shader = @import("./shader.zig");
+
+const ComputePipelineOpts = struct {
+    device: c.VkDevice,
+    queue_family_index: u32,
+    allocator: std.mem.Allocator,
+};
+
+fn createBackgroundPipeline(_: std.mem.Allocator, _: ComputePipelineOpts) void {
+    // const gradient_shader = try shader.createShaderModule(a, opts.device, "zig-out/shaders/gradient.comp.spv");
+
+    // const pipeline_layout_create_info = c.VkPipelineLayoutCreateInfo{
+    //     .sType = c.VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+    //     .setLayoutCount = 0,
+    //     .pSetLayouts = null,
+    //     .pushConstantRangeCount = 0,
+    //     .pPushConstantRanges = null,
+    // };
+}
+
+fn clear() void {
+
+}

--- a/src/vulkan/data.zig
+++ b/src/vulkan/data.zig
@@ -1,0 +1,6 @@
+const c = @import("../clibs.zig");
+
+pub const Pipeline = struct {
+    handle: c.VkPipeline,
+    layout: c.VkPipelineLayout = undefined,
+};

--- a/src/vulkan/descriptor_set.zig
+++ b/src/vulkan/descriptor_set.zig
@@ -35,6 +35,28 @@ pub const DescriptorPool = struct {
     handle: c.VkDescriptorPool,
 };
 
+pub fn createGridDescriptorSetLayout(device: c.VkDevice) !DescriptorSetLayout {
+    const camera_binding_info = std.mem.zeroInit(c.VkDescriptorSetLayoutBinding, .{
+        .binding = 0,
+        .descriptorType = c.VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+        .descriptorCount = 1,
+        .stageFlags = c.VK_SHADER_STAGE_VERTEX_BIT,
+        .pImmutableSamplers = null,
+    });
+
+    const bindings = [_]c.VkDescriptorSetLayoutBinding{ camera_binding_info };
+
+    var layout_info = std.mem.zeroInit(c.VkDescriptorSetLayoutCreateInfo, .{
+        .sType = c.VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+        .bindingCount = @as(u32, bindings.len),
+        .pBindings = &bindings,
+    });
+
+    var layout: c.VkDescriptorSetLayout = undefined;
+    try vke.checkResult(c.vkCreateDescriptorSetLayout(device, &layout_info, null, &layout));
+    return DescriptorSetLayout{ .handle = layout };
+}
+
 // This creates the descriptor set layout for the uniform buffer that will be used in the vertex shader.
 pub fn createDescriptorSetLayout(device: c.VkDevice) !DescriptorSetLayout {
     const camera_binding_info = std.mem.zeroInit(c.VkDescriptorSetLayoutBinding, .{
@@ -210,6 +232,43 @@ pub fn createSamplerDescriptorPool(device: c.VkDevice, max_objects: u32) !Descri
     try vke.checkResult(c.vkCreateDescriptorPool(device, &pool_info, null, &pool));
     return .{ .handle = pool };
 }
+
+// pub fn createGridDescriptorSets(a: std.mem.Allocator, buffer_count: u32, device: c.VkDevice, descriptor_pool: c.VkDescriptorPool, descriptor_set_layout: c.VkDescriptorSetLayout, buffer_set: []BufferSet, light_uniform_alignment: u64) ![]c.VkDescriptorSet {
+//     var layouts = [_]c.VkDescriptorSetLayout{ descriptor_set_layout, descriptor_set_layout };
+
+//     var alloc_info = std.mem.zeroInit(c.VkDescriptorSetAllocateInfo, .{
+//         .sType = c.VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+//         .descriptorPool = descriptor_pool,
+//         .descriptorSetCount = buffer_count,
+//         .pSetLayouts = &layouts,
+//     });
+    
+//     const sets = try a.alloc(c.VkDescriptorSet, buffer_count);
+//     try vke.checkResult(c.vkAllocateDescriptorSets(device, &alloc_info, sets.ptr));
+
+//     for (sets, 0..) |set, i| {
+//         const camera_buffer_info = std.mem.zeroInit(c.VkDescriptorBufferInfo, .{
+//             .buffer = buffer_set[i].camera.handle,
+//             .offset = 0,
+//             .range = @sizeOf(scene.Camera),
+//         });
+
+//         const camera_set_writes = std.mem.zeroInit(c.VkWriteDescriptorSet, .{
+//             .sType = c.VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+//             .dstSet = set,
+//             .dstBinding = 0,
+//             .dstArrayElement = 0,
+//             .descriptorType = c.VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+//             .descriptorCount = 1,
+//             .pBufferInfo = &camera_buffer_info,
+//         });
+
+//         const descriptor_writes = [_]c.VkWriteDescriptorSet{ camera_set_writes };
+//         c.vkUpdateDescriptorSets(device, @as(u32, descriptor_writes.len), &descriptor_writes, 0, null);
+//     }
+
+//     return sets;
+// }
 
 pub fn createDescriptorSets(a: std.mem.Allocator, buffer_count: u32, device: c.VkDevice, descriptor_pool: c.VkDescriptorPool, descriptor_set_layout: c.VkDescriptorSetLayout, buffer_set: []BufferSet, light_uniform_alignment: u64) ![]c.VkDescriptorSet {
     var layouts = [_]c.VkDescriptorSetLayout{ descriptor_set_layout, descriptor_set_layout };

--- a/src/vulkan/engine.zig
+++ b/src/vulkan/engine.zig
@@ -774,7 +774,7 @@ fn beginCommands(it: *ecs.iter_t) callconv(.C) void {
         const descriptor_sets_ref = descriptor_sets_refs[i];
 
         const buffer_begin_info = c.VkCommandBufferBeginInfo{ .sType = c.VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
-        const color_clear_value = c.VkClearValue{ .color = .{ .float32 = [_]f32{ 0.3, 0.3, 0.4, 1.0 } } };
+        const color_clear_value = c.VkClearValue{ .color = .{ .float32 = [_]f32{ 0.0, 0.0, 0.0, 1.0 } } };
         const depth_clear_value = c.VkClearValue{ .depthStencil = .{ .depth = 1.0, .stencil = 0 } };
 
         var clear_values: [2]c.VkClearValue = .{

--- a/src/vulkan/pipeline.zig
+++ b/src/vulkan/pipeline.zig
@@ -1,8 +1,12 @@
 const std = @import("std");
+const ecs = @import("flecs");
 const c = @import("../clibs.zig");
 const vke = @import ("./error.zig");
 const shader = @import("./shader.zig");
 const scene = @import("scene");
+const data = @import("data.zig");
+
+const Pipeline = data.Pipeline;
 
 const GraphicsPipelineOpts = struct {
     device: c.VkDevice,
@@ -11,11 +15,6 @@ const GraphicsPipelineOpts = struct {
     sampler_descriptor_set_layout: c.VkDescriptorSetLayout,
     swapchain_extent: c.VkExtent2D,
     push_constant_range: c.VkPushConstantRange,
-};
-
-const Pipeline = struct {
-    graphics_pipeline_handle: c.VkPipeline,
-    layout: c.VkPipelineLayout = undefined,
 };
 
 pub fn createGraphicsPipeline(a: std.mem.Allocator, opts: GraphicsPipelineOpts) !Pipeline {
@@ -199,7 +198,166 @@ pub fn createGraphicsPipeline(a: std.mem.Allocator, opts: GraphicsPipelineOpts) 
     c.vkDestroyShaderModule(opts.device, vertex_shader, null);
 
     return .{
-        .graphics_pipeline_handle = graphics_pipeline,
+        .handle = graphics_pipeline,
+        .layout = pipeline_layout,
+    };
+}
+
+pub fn createGridPipeline(a: std.mem.Allocator, opts: GraphicsPipelineOpts) !Pipeline {
+    const vertex_shader = try shader.createShaderModule(a, opts.device, "zig-out/shaders/grid.vert.spv");
+    const fragment_shader = try shader.createShaderModule(a, opts.device, "zig-out/shaders/grid.frag.spv");
+
+    const vertex_shader_create_info = std.mem.zeroInit(c.VkPipelineShaderStageCreateInfo, .{
+        .sType = c.VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+        .stage = c.VK_SHADER_STAGE_VERTEX_BIT,
+        .module = vertex_shader,
+        .pName = "main",
+    });
+
+    const frag_shader_create_info = std.mem.zeroInit(c.VkPipelineShaderStageCreateInfo, .{
+        .sType = c.VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+        .stage = c.VK_SHADER_STAGE_FRAGMENT_BIT,
+        .module = fragment_shader,
+        .pName = "main",
+    });
+
+    var shader_stages = [_]c.VkPipelineShaderStageCreateInfo {
+        vertex_shader_create_info,
+        frag_shader_create_info,
+    }; 
+
+    const binding_description: c.VkVertexInputBindingDescription = .{
+        .binding = 0,
+        .stride = @sizeOf(scene.Vertex),
+        .inputRate = c.VK_VERTEX_INPUT_RATE_VERTEX,
+    };
+
+    const vertex_input_create_info = std.mem.zeroInit(c.VkPipelineVertexInputStateCreateInfo, .{
+        .sType = c.VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO,
+        .vertexBindingDescriptionCount = 1,
+        .pVertexBindingDescriptions = &binding_description,
+        .vertexAttributeDescriptionCount = 0,
+        .pVertexAttributeDescriptions = null,
+    });
+
+    const input_assembly_create_info = std.mem.zeroInit(c.VkPipelineInputAssemblyStateCreateInfo, .{
+        .sType = c.VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
+        .topology = c.VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST,
+        .primitiveRestartEnable = c.VK_FALSE,
+    });
+
+    const viewport = c.VkViewport {
+        .x = 0.0,
+        .y = 0.0,
+        .width = @as(f32, @floatFromInt(opts.swapchain_extent.width)),
+        .height = @as(f32, @floatFromInt(opts.swapchain_extent.height)),
+        .minDepth = 0.0,
+        .maxDepth = 1.0,
+    };
+
+    const scissor = c.VkRect2D {
+        .offset = .{
+            .x = 0,
+            .y = 0,
+        }, 
+        .extent = opts.swapchain_extent,
+    };
+
+    const viewport_create_info = std.mem.zeroInit(c.VkPipelineViewportStateCreateInfo, .{
+        .sType = c.VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
+        .viewportCount = 1,
+        .pViewports = &viewport,
+        .scissorCount = 1,
+        .pScissors = &scissor,
+    });
+
+    const rasterization_create_info = std.mem.zeroInit(c.VkPipelineRasterizationStateCreateInfo, .{
+        .sType = c.VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
+        .depthClampEnable = c.VK_FALSE,
+        .rasterizerDiscardEnable = c.VK_FALSE,
+        .polygonMode = c.VK_POLYGON_MODE_FILL,
+        .lineWidth = 1.0,
+        .cullMode = c.VK_CULL_MODE_BACK_BIT,
+        .frontFace = c.VK_FRONT_FACE_COUNTER_CLOCKWISE,
+        .depthBiasEnable = c.VK_FALSE,
+    });
+
+    const multisample_create_info = std.mem.zeroInit(c.VkPipelineMultisampleStateCreateInfo, .{
+        .sType = c.VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
+        .sampleShadingEnable = c.VK_FALSE,
+        .rasterizationSamples = c.VK_SAMPLE_COUNT_1_BIT,
+        .minSampleShading = 1.0,
+    });
+
+    const color_blend_attachment = std.mem.zeroInit(c.VkPipelineColorBlendAttachmentState, .{
+        .colorWriteMask = c.VK_COLOR_COMPONENT_R_BIT
+            | c.VK_COLOR_COMPONENT_G_BIT
+            | c.VK_COLOR_COMPONENT_B_BIT
+            | c.VK_COLOR_COMPONENT_A_BIT,
+        .blendEnable = c.VK_TRUE,
+        .srcColorBlendFactor = c.VK_BLEND_FACTOR_SRC_ALPHA,
+        .dstColorBlendFactor = c.VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
+        .colorBlendOp = c.VK_BLEND_OP_ADD,
+        .srcAlphaBlendFactor = c.VK_BLEND_FACTOR_ONE,
+        .dstAlphaBlendFactor = c.VK_BLEND_FACTOR_ZERO,
+    });
+
+    const color_blending_create_info = std.mem.zeroInit(c.VkPipelineColorBlendStateCreateInfo, .{
+        .sType = c.VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
+        .logicOpEnable = c.VK_FALSE,
+        .attachmentCount = 1,
+        .pAttachments = &color_blend_attachment,
+    });
+
+    const descriptor_set_layouts = [_]c.VkDescriptorSetLayout{opts.descriptor_set_layout, opts.sampler_descriptor_set_layout};
+
+    const pipeline_layout_create_info = std.mem.zeroInit(c.VkPipelineLayoutCreateInfo, .{
+        .sType = c.VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+        .setLayoutCount = @as(u32, @intCast(descriptor_set_layouts.len)),
+        .pSetLayouts = &descriptor_set_layouts,
+        .pushConstantRangeCount = 1,
+        .pPushConstantRanges = &opts.push_constant_range,
+    });
+
+    var pipeline_layout: c.VkPipelineLayout = undefined;
+    try vke.checkResult(c.vkCreatePipelineLayout(opts.device, &pipeline_layout_create_info, null, &pipeline_layout));
+
+    const depth_stencil_create_info = std.mem.zeroInit(c.VkPipelineDepthStencilStateCreateInfo, .{
+        .sType = c.VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO,
+        .depthTestEnable = c.VK_TRUE,
+        .depthWriteEnable = c.VK_TRUE,
+        .depthCompareOp = c.VK_COMPARE_OP_LESS,
+        .depthBoundsTestEnable = c.VK_FALSE,
+        .stencilTestEnable = c.VK_FALSE,
+    });
+
+    var graphics_pipeline_create_info = std.mem.zeroInit(c.VkGraphicsPipelineCreateInfo, .{
+        .sType = c.VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
+        .stageCount = shader_stages.len,
+        .pStages = &shader_stages,
+        .pVertexInputState = &vertex_input_create_info,
+        .pInputAssemblyState = &input_assembly_create_info,
+        .pViewportState = &viewport_create_info,
+        .pDynamicState = null,
+        .pRasterizationState = &rasterization_create_info,
+        .pMultisampleState = &multisample_create_info,
+        .pColorBlendState = &color_blending_create_info,
+        .pDepthStencilState = &depth_stencil_create_info,
+        .layout = pipeline_layout,
+        .renderPass = opts.render_pass,
+        .subpass = 0,
+        .basePipelineHandle = null,
+        .basePipelineIndex = -1,
+    });
+
+    var graphics_pipeline: c.VkPipeline = undefined;
+    try vke.checkResult(c.vkCreateGraphicsPipelines(opts.device, null, 1, &graphics_pipeline_create_info, null, &graphics_pipeline));
+
+    c.vkDestroyShaderModule(opts.device, fragment_shader, null);
+    c.vkDestroyShaderModule(opts.device, vertex_shader, null);
+
+    return .{
+        .handle = graphics_pipeline,
         .layout = pipeline_layout,
     };
 }

--- a/src/vulkan/pipeline.zig
+++ b/src/vulkan/pipeline.zig
@@ -63,6 +63,12 @@ pub fn createGraphicsPipeline(a: std.mem.Allocator, opts: GraphicsPipelineOpts) 
         .{
             .binding = 0,
             .location = 2,
+            .format = c.VK_FORMAT_R32G32B32_SFLOAT,
+            .offset = @offsetOf(scene.Vertex, "normal"),
+        },
+        .{
+            .binding = 0,
+            .location = 3,
             .format = c.VK_FORMAT_R32G32_SFLOAT,
             .offset = @offsetOf(scene.Vertex, "uv"),
         }

--- a/src/vulkan/pipeline.zig
+++ b/src/vulkan/pipeline.zig
@@ -226,16 +226,16 @@ pub fn createGridPipeline(a: std.mem.Allocator, opts: GraphicsPipelineOpts) !Pip
         frag_shader_create_info,
     }; 
 
-    const binding_description: c.VkVertexInputBindingDescription = .{
-        .binding = 0,
-        .stride = @sizeOf(scene.Vertex),
-        .inputRate = c.VK_VERTEX_INPUT_RATE_VERTEX,
-    };
+    // const binding_description: c.VkVertexInputBindingDescription = .{
+    //     .binding = 0,
+    //     .stride = @sizeOf(scene.Vertex),
+    //     .inputRate = c.VK_VERTEX_INPUT_RATE_VERTEX,
+    // };
 
     const vertex_input_create_info = std.mem.zeroInit(c.VkPipelineVertexInputStateCreateInfo, .{
         .sType = c.VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO,
-        .vertexBindingDescriptionCount = 1,
-        .pVertexBindingDescriptions = &binding_description,
+        .vertexBindingDescriptionCount = 0,
+        .pVertexBindingDescriptions = null,
         .vertexAttributeDescriptionCount = 0,
         .pVertexAttributeDescriptions = null,
     });
@@ -309,14 +309,14 @@ pub fn createGridPipeline(a: std.mem.Allocator, opts: GraphicsPipelineOpts) !Pip
         .pAttachments = &color_blend_attachment,
     });
 
-    const descriptor_set_layouts = [_]c.VkDescriptorSetLayout{opts.descriptor_set_layout, opts.sampler_descriptor_set_layout};
+    const descriptor_set_layouts = [_]c.VkDescriptorSetLayout{opts.descriptor_set_layout };
 
     const pipeline_layout_create_info = std.mem.zeroInit(c.VkPipelineLayoutCreateInfo, .{
         .sType = c.VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
         .setLayoutCount = @as(u32, @intCast(descriptor_set_layouts.len)),
         .pSetLayouts = &descriptor_set_layouts,
-        .pushConstantRangeCount = 1,
-        .pPushConstantRanges = &opts.push_constant_range,
+        .pushConstantRangeCount = 0,
+        .pPushConstantRanges = null,
     });
 
     var pipeline_layout: c.VkPipelineLayout = undefined;


### PR DESCRIPTION
I made an attempt to create some basic diffuse and ambient lighting in the scene.  I was running into issues and thought one of the meshes was being made transparent.  I decided to add an infinite grid to the scene so I could keep my bearing as I move the 3D meshes throughout the scene.

This led to some bigger changes in this pull request than what I had anticipated.  First, I had to set up a new graphics pipeline for the new grid shader.  I didn't want to set up a new set of buffers to pass the `ViewProjection` (aka camera) into the shader, so I refactored the existing descriptor set layouts and descriptor sets so I could pass that to both graphics pipelines.  

In the end, I was able to get an infinite grid, albeit it does need to be cleaned up but it is a start.  I also have the lighting working at the most basic and trivial level.

The code needs to be cleaned up quite a bit.  The two rendering pipelines are kind of a mess and everything is mixed together.  However, this PR already has enough changes in it and I am happy with the current state, so I will merge and address the refactoring in a separate issue in the near future.